### PR TITLE
Remove changes to require.paths

### DIFF
--- a/Node/config.js
+++ b/Node/config.js
@@ -1,6 +1,6 @@
 var EventEmitter = require('events').EventEmitter,
-    extend = require('misc').extend,
-    composePath = require('misc').composePath,
+    extend = require('./misc').extend,
+    composePath = require('./misc').composePath,
     fs = require('fs'),
     singleton;
 

--- a/Node/nodekit.js
+++ b/Node/nodekit.js
@@ -1,17 +1,16 @@
 var termkit = {
   version: 1,
 };
-require.paths.unshift('./socket.io-node/lib');
-require.paths.unshift('.');
-require.paths.unshift('../Shared/');
+
+require.paths.unshift(__dirname + '/../Shared/');
 
 // Load requirements.
 var http = require('http'),  
-    io = require('socket.io')
-    router = require("router");
+    io = require('./socket.io-node'),
+    router = require("./router");
 
 // Load config file.
-var config = require('config').getConfig();
+var config = require('./config').getConfig();
 
 // Set up http server.
 var server = http.createServer(function (request, result) { 

--- a/Node/router.js
+++ b/Node/router.js
@@ -1,5 +1,5 @@
-var shell = require("shell/shell");
-var returnMeta = require('misc').returnMeta;
+var shell = require('./shell');
+var returnMeta = require('./misc').returnMeta;
 var protocol = require('protocol');
 
 /**

--- a/Node/shell/index.js
+++ b/Node/shell/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./shell');

--- a/Node/shell/shell.js
+++ b/Node/shell/shell.js
@@ -3,7 +3,7 @@ var fs = require('fs'), net = require('net');
 var spawn = require('child_process').spawn,
     exec = require('child_process').exec;
 
-var config = require('config').getConfig();
+var config = require('../config').getConfig();
 
 exports.shell = function (args, router) {
 


### PR DESCRIPTION
Changing require.paths is naughty and might stop working in a future node.js version:
http://nodejs.org/docs/v0.4.7/api/modules.html#_Note_Please_Avoid_Modifying_require.paths_

This also fixes a bug whereby running the nodejs app from a different
directory wouldn't work.

This works too now:

TermKit $ node Node/nodekit.js 
19 May 01:36:42 - socket.io ready - accepting connections

(Sorry about the pull request earlier - I didn't mean to conflate all those commits)
