### PR TITLE
simple ansi color handling for binary output

### DIFF
--- a/HTML/termkit.css
+++ b/HTML/termkit.css
@@ -506,3 +506,66 @@ iframe#usage {
   margin: 0;
   padding: 0;
 }
+
+.color0 {
+  // use default here
+}
+.color1 {
+  color: #c00;
+}
+.color2 {
+  color: #4E9A06;
+}
+.color3 {
+  color: #C4A000;
+}
+.color4 {
+  color: #3465A4;
+}
+.color5 {
+  color: #75507B;
+}
+.color6 {
+  color: #06989A;
+}
+.color7 {
+  color: #2E3436;
+}
+
+.bcolor0 {
+  color: #EEEEEC;
+  font-weight: bolder;
+}
+.bcolor1 {
+  color: #EF2929;
+  font-weight: bolder;
+}
+.bcolor2 {
+  color: #8AE234;
+  font-weight: bolder;
+}
+.bcolor3 {
+  color: #FCE94F;
+  font-weight: bolder;
+}
+.bcolor4 {
+  color: #729FCF;
+  font-weight: bolder;
+}
+.bcolor5 {
+  color: #729FCF;
+  font-weight: bolder;
+}
+.bcolor6 {
+  color: #AD7FA8;
+  font-weight: bolder;
+}
+.bcolor7 {
+  color: #555753;
+  font-weight: bolder;
+}
+
+div.ansi {
+  font-family: "BitStream Vera Sans Mono", "Lucida Console", monospace;
+  font-size: 120%;
+}

--- a/Node/misc.js
+++ b/Node/misc.js
@@ -269,7 +269,7 @@ exports.ansi2html = function(input /* Buffer */) {
 
         write('">');
 
-        write(input.slice(lastStart, i).toString());
+        write(input.slice(lastStart, i).toString().replace(/&/g, "&amp;").replace(/</g, "&lt;"));
         //write(''+lastStart+":"+i)
         write('</span>');
       }

--- a/Node/shell/formatter.js
+++ b/Node/shell/formatter.js
@@ -393,7 +393,7 @@ exports.plugins.binary.prototype = extend(new exports.plugin(), {
 
   ansi: false,
   data: function (data) {
-    if (this.ansi || /\\u001b/(data.toString())) {
+    if (this.ansi || /\\e[\\[]/(data.toString())) {
       this.ansi = true; // switch to ansi mode as soon as we detect the CSI
       this.out.update('ansi', { contents: '<div class="ansi">'+ansi2html(data)+'</div>' }, true);
     }


### PR DESCRIPTION
Hi,

I added simple ANSI-Color parsing which is activated for binary output if the start of an ansi sequence was found.

If you want that to work for your git output you have to override git's tty recognition (`isatty` which won't work with TermKit) by setting `diff.color="always"` etc.
