### PR TITLE
Feature: install app utility

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ Unfortunately, TermKit currently requires some assembly.
 5. Clone the TermKit repository: `git clone https://github.com/unconed/TermKit.git --recursive`
 6. Users of older git versions will need to type: `git submodule update --init`
 7. Run the NodeKit daemon: `cd TermKit/Node; node nodekit.js`
-8. Unzip and run the Mac app in Build/TermKit.zip
+8. Run `bin/termkit_install_app` to install into Applications (or manually unzip and run the Mac app in Build/TermKit.zip)
 
 *Tip:* Press ⌥⌘C to access the WebKit console.
 

--- a/bin/termkit_install_app
+++ b/bin/termkit_install_app
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+DIRECTORY=$(cd `dirname $0` && cd .. && pwd)
+
+unzip $DIRECTORY/Build/TermKit.zip -d $DIRECTORY/Build > /dev/null
+cp -R $DIRECTORY/Build/TermKit.app /Applications
+rm -rf $DIRECTORY/Build/TermKit.app
+
+echo "TermKit.app => Applications"
+echo "Enjoy!"


### PR DESCRIPTION
Hi,

I started out by wanting to be able to install TermKit via homebrew, and 1) realized that there was no recipe for TermKit there, and 2) realized that in order for there to be one, we would need to abstract the TermKit.app installation into a utility (because homebrew philosophy is to not generate apps while installing).

In summary, I'm asking for a pull request for this admittedly very simple feature (or non-feature, if you will) so that I can make a homebrew recipe for TermKit.

I've added to the last step of the installation documentation to reflect my addition.

Also, I just wanted to say I really admire this project and your insights behind it :)
