### PR TITLE
Adding a nodekit script as a commandline shortcut to start the server.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ Unfortunately, TermKit currently requires some assembly.
 4. Install node-mime: `npm install mime`
 5. Clone the TermKit repository: `git clone https://github.com/unconed/TermKit.git --recursive`
 6. Users of older git versions will need to type: `git submodule update --init`
-7. Run the NodeKit daemon: `cd TermKit/Node; node nodekit.js`
+7. Run the NodeKit daemon: `TermKit/bin/nodekit` or `cd TermKit/Node; node nodekit.js`
 8. Unzip and run the Mac app in Build/TermKit.zip
 
 *Tip:* Press ⌥⌘C to access the WebKit console.

--- a/bin/nodekit
+++ b/bin/nodekit
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIRECTORY=$(cd `dirname $0` && cd .. && pwd)
+cd $DIRECTORY/Node; node nodekit.js


### PR DESCRIPTION
The title says it all. :)

This is so when we install via homebrew, we can symlink the script to the binary path and simply run `nodekit` to start up the backend server.
