### PR TITLE
Cocoa: build correctly on case-sensitive HFS+ (HFSX)

### DIFF
--- a/Build/build.sh
+++ b/Build/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 rm -rf TermKit.*
-cp -R ../Cocoa/TermKit/Build/Release/TermKit.app .
+cp -R ../Cocoa/TermKit/build/Release/TermKit.app .
 zip -r TermKit.zip TermKit.app


### PR DESCRIPTION
The build.sh to bundle the TermKit.app built by xcode into the TermKit.zip file refers to the build directory as "../Cocoa/TermKit/Build", but Xcode (on my system, at least), creates the directory as "../build", causing build.sh to fail when TermKit is being built on HFSX.

Note: I'm running Leopard's Xcode, so it's probably worth double-checking to make sure Snow Leopard's Xcode also creates the build directory with a lowercase B.

~jon.
